### PR TITLE
SnapMirror active sync multipath timeout settings update for Oracle Linux 8 and 9

### DIFF
--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -1,0 +1,165 @@
+[role="tabbed-block"]
+=====
+.Oracle Linux Host
+--
+To ensure that multipathing is configured correctly for your host, verify that `/etc/multipath.conf` is defined and that the NetApp-recommended settings are configured for your ONTAP LUNs.
+
+.Steps
+
+. Verify that the `/etc/multipath.conf` file exists. If the file doesn't exist, create an empty, zero-byte file:
++
+[source,cli]
+----
+touch /etc/multipath.conf
+----
+
+. The first time the `multipath.conf` file is created, you might need to enable and start the multipath services to load the recommended settings:
++
+[source,cli]
+----
+systemctl enable multipathd
+----
++
+[source,cli]
+----
+systemctl start multipathd
+----
+
+. Each time you boot the host, the empty `/etc/multipath.conf` zero-byte file automatically loads the NetApp recommended host multipath parameters as the default settings. You shouldn't need to make changes to the `/etc/multipath.conf` file for your host because the operating system is compiled with the multipath parameters that recognize and manage ONTAP LUNs correctly.
++
+The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
++
+.Show parameter settings
+[%collapsible]
+====
+[[ol-8-9-multipath-parameter-settings]]
+[cols=2]
+[options="header"]
+|===
+| Parameter
+| Setting
+| detect_prio | yes
+| dev_loss_tmo | "infinity"
+| failback | immediate
+| fast_io_fail_tmo | 5
+| features | "2 pg_init_retries 50"
+| flush_on_last_del | "yes"
+| hardware_handler | "0"
+| no_path_retry | queue
+| path_checker | "tur"
+| path_grouping_policy | "group_by_prio"
+| path_selector | "service-time 0"
+| polling_interval | 5
+| prio | "ontap"
+| product | LUN
+| retain_attached_hw_handler | yes
+| rr_weight | "uniform"
+| user_friendly_names | no
+| vendor | NETAPP
+|===
+====
+
+. Verify the parameter settings and path status for your ONTAP LUNs:
++
+[source,cli]
+----
+multipath -ll
+----
++
+The default multipath parameters support ASA, AFF, and FAS configurations. In these configurations, a single ONTAP LUN shouldn't require more than four paths. Having more than four paths can cause problems during a storage failure.
++
+The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
+
+*ASA configuration*
+
+An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
+
+.Show example
+[%collapsible]
+====
+----
+multipath -ll
+3600a098038303634722b4d59646c4436 dm-28 NETAPP,LUN C-Mode
+size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=rw
+|-+- policy='service-time 0' prio=50 status=active
+  |- 11:0:7:6   sdbz 68:208  active ready running
+  |- 11:0:11:6  sddn 71:80   active ready running
+  |- 11:0:15:6  sdfb 129:208 active ready running
+  |- 12:0:1:6   sdgp 132:80  active ready running
+----
+====
+
+*AFF or FAS configuration*
+
+An AFF or FAS configuration should have two groups of paths with higher and lower priorities. Higher priority Active/Optimized paths are served by the controller where the aggregate is located. Lower priority paths are active but non-optimized because they are served by a different controller. Non-optimized paths are only used when optimized paths aren’t available.
+
+The following example displays the output for an ONTAP LUN with two Active/Optimized paths and two Active/Non-Optimized paths:
+
+.Show example
+[%collapsible]
+====
+----
+multipath -ll
+3600a0980383036347ffb4d59646c4436 dm-28 NETAPP,LUN C-Mode
+size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=rw
+|-+- policy='service-time 0' prio=50 status=active
+| |- 16:0:6:35 sdwb  69:624  active ready running
+| |- 16:0:5:35 sdun  66:752  active ready running
+`-+- policy='service-time 0' prio=10 status=enabled
+  |- 15:0:0:35 sdaj  66:48   active ready running
+  |- 15:0:1:35 sdbx  68:176  active ready running
+----
+====
+--
+
+.OLVM - ONTAP HA
+--
+In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
+
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<ol-8-9-multipath-parameter-settings,Oracle Linux Host parameter settings table>>.
+
+.Steps
+
+. Create the drop-in file:
++
+[source,cli]
+----
+cat <<'EOF' > /etc/multipath/conf.d/ontap-ha-mpath-netapp.conf
+# Finite multipath retry window aligned with sanlock io_timeout
+# default sanlock:io_timeout=10s, polling_interval=5s => no_path_retry = (8*10)/5 = 16
+
+devices {
+  device {
+    vendor "NETAPP"
+    product "LUN"
+    no_path_retry 16
+    dev_loss_tmo "infinity"
+  }
+}
+EOF
+----
+
+. Reload the multipath daemon:
++
+[source,cli]
+----
+systemctl reload multipathd
+----
+
+. Verify the updated multipath configuration:
++
+[source,cli]
+----
+multipathd -k"show config"
+----
+--
+
+.OLVM - ONTAP SnapMirror active sync
+--
+In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
+
+When OLVM hosts use ONTAP SnapMirror active sync, it is recommended to adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
+
+Follow the configuration steps in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to update the sanlock and multipath timeout values so the lease renewal window remains sufficient for multipath recovery to complete during a storage failover event.
+--
+=====

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -114,9 +114,9 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 
 .OLVM - ONTAP HA
 --
-In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
+In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override `dev_loss_tmo` and `no_path_retry`. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
 
 .Steps
 
@@ -156,7 +156,7 @@ multipathd -k"show config"
 
 .OLVM - ONTAP SnapMirror active sync
 --
-In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
+In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
 When OLVM hosts use ONTAP SnapMirror active sync, it is recommended to adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -116,7 +116,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<multipath-parameter-settings-table,Oracle Linux Host parameter settings table>>.
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
 
 .Steps
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -114,7 +114,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 
 .OLVM - ONTAP HA
 --
-In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
+In Oracle Linux Virtualization Manager (OLVM), the VDSM daemon controls the default multipath parameters on the hypervisor. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
 For ONTAP high-availability (HA) configurations, NetApp recommends the following drop-in file to override `dev_loss_tmo` and `no_path_retry`. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -158,7 +158,7 @@ multipathd -k"show config"
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
-When OLVM hosts use ONTAP SnapMirror active sync, it is recommended to adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
+When OLVM hosts use ONTAP SnapMirror active sync, you should adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
 
 Follow the configuration steps in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to update the sanlock and multipath timeout values so the lease renewal window remains sufficient for multipath recovery to complete during a storage failover event.
 --

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -69,11 +69,11 @@ multipath -ll
 The default multipath parameters support ASA, AFF, and FAS configurations. In these configurations, a single ONTAP LUN shouldn't require more than four paths. Having more than four paths can cause problems during a storage failure.
 +
 The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
-
++
 *ASA configuration*
-
++
 An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
-
++
 .Show example
 [%collapsible]
 ====
@@ -88,13 +88,13 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 12:0:1:6   sdgp 132:80  active ready running
 ----
 ====
-
++
 *AFF or FAS configuration*
-
++
 An AFF or FAS configuration should have two groups of paths with higher and lower priorities. Higher priority Active/Optimized paths are served by the controller where the aggregate is located. Lower priority paths are active but non-optimized because they are served by a different controller. Non-optimized paths are only used when optimized paths aren’t available.
-
++
 The following example displays the output for an ONTAP LUN with two Active/Optimized paths and two Active/Non-Optimized paths:
-
++
 .Show example
 [%collapsible]
 ====

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -116,7 +116,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the xref:ol-8-9-multipath-parameter-settings[Oracle Linux Host parameter settings table].
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<ol-8-9-multipath-parameter-settings,Oracle Linux Host parameter settings table>>.
 
 .Steps
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -158,7 +158,7 @@ multipathd -k"show config"
 --
 In Oracle Linux Virtualization Manager (OLVM), the VDSM daemon controls the default multipath parameters on the hypervisor. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
-When OLVM hosts use ONTAP SnapMirror active sync, it is recommended to adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
+When OLVM hosts use ONTAP SnapMirror active sync, you should adjust `sanlock `and `multipath timeout` values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window might expire before multipath recovery completes.
 
 Follow the configuration steps in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to update the sanlock and multipath timeout values so the lease renewal window remains sufficient for multipath recovery to complete during a storage failover event.
 --

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -116,7 +116,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<ol-8-9-multipath-parameter-settings,Oracle Linux Host parameter settings table>>.
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the xref:ol-8-9-multipath-parameter-settings[Oracle Linux Host parameter settings table].
 
 .Steps
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -29,7 +29,7 @@ systemctl start multipathd
 +
 The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
 +
-[[ol-8-9-multipath-parameter-settings]]
+[[multipath-parameter-settings-table]]
 .Show parameter settings
 [%collapsible]
 ====
@@ -116,7 +116,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit /etc/multipath.conf directly.Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<ol-8-9-multipath-parameter-settings,Oracle Linux Host parameter settings table>>.
+For ONTAP HA configurations, NetApp recommends the following drop-in file to override dev_loss_tmo and no_path_retry. All other multipath parameters should match the settings in the <<multipath-parameter-settings-table,Oracle Linux Host parameter settings table>>.
 
 .Steps
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -156,7 +156,7 @@ multipathd -k"show config"
 
 .OLVM - ONTAP SnapMirror active sync
 --
-In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
+In Oracle Linux Virtualization Manager (OLVM), the VDSM daemon controls the default multipath parameters on the hypervisor. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
 When OLVM hosts use ONTAP SnapMirror active sync, it is recommended to adjust sanlock and multipath timeout values to ensure correct host and VM behavior during storage failover events. The default OLVM timeout values can cause unintended high-availability VM failovers during unplanned site failovers because the lease renewal window may expire before multipath recovery completes.
 

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -29,10 +29,10 @@ systemctl start multipathd
 +
 The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
 +
+[[ol-8-9-multipath-parameter-settings]]
 .Show parameter settings
 [%collapsible]
 ====
-[[ol-8-9-multipath-parameter-settings]]
 [cols=2]
 [options="header"]
 |===

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -29,7 +29,7 @@ systemctl start multipathd
 +
 The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
 +
-[[multipath-parameter-settings-table]]
+[[multipath-parameter-settings]]
 .Show parameter settings
 [%collapsible]
 ====

--- a/_include/hu/linux-ol-8-9-multipathing.adoc
+++ b/_include/hu/linux-ol-8-9-multipathing.adoc
@@ -116,7 +116,7 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 --
 In Oracle Linux Virtualization Manager (OLVM), default multipath parameters on the hypervisor are controlled by the VDSM daemon. Do not edit `/etc/multipath.conf` directly. Instead, override the defaults using a multipath drop-in file.
 
-For ONTAP HA configurations, NetApp recommends the following drop-in file to override `dev_loss_tmo` and `no_path_retry`. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
+For ONTAP high-availability (HA) configurations, NetApp recommends the following drop-in file to override `dev_loss_tmo` and `no_path_retry`. All other multipath parameters should match the settings in the Oracle Linux Host parameter settings table.
 
 .Steps
 

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -1,15 +1,19 @@
-To ensure that multipathing is configured correctly for your host, verify that the `/etc/multipath.conf` file is defined and that you have the NetApp recommended settings configured for your ONTAP LUNs.
+[role="tabbed-block"]
+=====
+.Oracle Linux Standalone
+--
+To ensure that multipathing is configured correctly for your host, verify that `/etc/multipath.conf` is defined and that the NetApp-recommended settings are configured for your ONTAP LUNs.
 
-.Steps 
+.Steps
 
-. Verify that the `/etc/multipath.conf` file exits. If the file doesn't exist, create an empty, zero-byte file:
+. Verify that the `/etc/multipath.conf` file exists. If the file doesn't exist, create an empty, zero-byte file:
 +
 [source,cli]
 ----
 touch /etc/multipath.conf
 ----
 
-. The first time the `multipath.conf` file is created, you might need to enable and start the multipath services to load the recommended settings: 
+. The first time the `multipath.conf` file is created, you might need to enable and start the multipath services to load the recommended settings:
 +
 [source,cli]
 ----
@@ -23,7 +27,7 @@ systemctl start multipathd
 
 . Each time you boot the host, the empty `/etc/multipath.conf` zero-byte file automatically loads the NetApp recommended host multipath parameters as the default settings. You shouldn't need to make changes to the `/etc/multipath.conf` file for your host because the operating system is compiled with the multipath parameters that recognize and manage ONTAP LUNs correctly.
 +
-The following table shows the Linux OS native compiled multipath parameter settings for ONTAP LUNs.
+The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
 +
 .Show parameter settings
 [%collapsible]
@@ -55,12 +59,6 @@ The following table shows the Linux OS native compiled multipath parameter setti
 |===
 ====
 
-. If your storage configuration includes SnapMirror active sync, additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events. 
-+
-In SnapMirror active sync environments using Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-avaialbility VM failovers during storage failover events. This occurs because the default lease renewal window may expire before multipath recovery completes.  
-+
-Perform the configuration steps described in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync] to adjust the sanlock and multipath timeout values to ensure that the lease renewal window is sufficient for multipath recovery to complete during a storage failover event.
-
 . Verify the parameter settings and path status for your ONTAP LUNs:
 +
 [source,cli]
@@ -70,13 +68,13 @@ multipath -ll
 +
 The default multipath parameters support ASA, AFF, and FAS configurations. In these configurations, a single ONTAP LUN shouldn't require more than four paths. Having more than four paths can cause problems during a storage failure.
 +
-The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration. 
+The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
 +
 [role="tabbed-block"]
 =====
 .ASA configuration
 --
-An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time. 
+An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
 
 .Show example
 [%collapsible]
@@ -115,5 +113,66 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 15:0:1:35 sdbx  68:176  active ready running
 ----
 ====
+--
+=====
+--
+
+.OLVM - ONTAP HA
+--
+If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon.
+
+It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
+
+NetApp recommends the following drop-in file for ONTAP HA configurations to override the default `dev_loss_tmo` and `no_path_retry` values. The remaining multipath parameters align with the table in the Oracle Linux Standalone tab.
+
+.Steps
+
+. Create the drop-in file and add the following content:
++
+[source,cli]
+----
+cat <<'EOF' > /etc/multipath/conf.d/ontap-ha-mpath-netapp.conf
+# Finite multipath retry window aligned with sanlock io_timeout
+# default sanlock:io_timeout=10s, polling_interval=5s => no_path_retry = (8*10)/5 = 16
+
+devices {
+  device {
+    vendor "NETAPP"
+    product "LUN"
+    no_path_retry 16
+    dev_loss_tmo "infinity"
+  }
+}
+EOF
+----
+
+. Reload the multipath daemon:
++
+[source,cli]
+----
+systemctl reload multipathd
+----
+
+. Verify the updated multipath configuration:
++
+[source,cli]
+----
+multipath -ll
+----
+--
+
+.OLVM - ONTAP SnapMirror active sync
+--
+If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon.
+
+It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
+
+.Steps
+
+. If you are using an ONTAP SnapMirror active sync configuration with Oracle Linux Virtualization Manager (OLVM), additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events.
++
+With Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-availability virtual machine (VM) failovers during unplanned storage site failover events. This occurs because the default lease renewal window can expire before multipath recovery completes.
++
+Perform the configuration steps described in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to adjust the sanlock and multipath timeout values to ensure that the lease renewal window is sufficient for multipath recovery to complete during a storage failover event.
 --
 =====

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -55,6 +55,16 @@ The following table shows the Linux OS native compiled multipath parameter setti
 |===
 ====
 
+. If your storage configuration includes SnapMirror active sync, additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events. 
+ 
+When SnapMirror active sync is used with Oracle Linux Virtualization Manager (OLVM), specific multipath and sanlock behavior must be configured to align host I/O retry handling with OLVM high-availability lease management.
+
+
+Refer to the NetApp Knowledge Base article
+https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync]
+for detailed configuration instructions.
+
+
 . Verify the parameter settings and path status for your ONTAP LUNs:
 +
 [source,cli]

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -70,10 +70,8 @@ The default multipath parameters support ASA, AFF, and FAS configurations. In th
 +
 The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
 +
-[role="tabbed-block"]
-=====
-.ASA configuration
---
+*ASA configuration*
+
 An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
 
 .Show example
@@ -90,10 +88,9 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 12:0:1:6   sdgp 132:80  active ready running
 ----
 ====
---
 
-.AFF or FAS configuration
---
+*AFF or FAS configuration*
+
 An AFF or FAS configuration should have two groups of paths with higher and lower priorities. Higher priority Active/Optimized paths are served by the controller where the aggregate is located. Lower priority paths are active but non-optimized because they are served by a different controller. Non-optimized paths are only used when optimized paths aren’t available.
 
 The following example displays the output for an ONTAP LUN with two Active/Optimized paths and two Active/Non-Optimized paths:
@@ -113,8 +110,6 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 15:0:1:35 sdbx  68:176  active ready running
 ----
 ====
---
-=====
 --
 
 .OLVM - ONTAP HA

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -56,10 +56,9 @@ The following table shows the Linux OS native compiled multipath parameter setti
 ====
 
 . If your storage configuration includes SnapMirror active sync, additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events. 
- 
++
 When SnapMirror active sync is used with Oracle Linux Virtualization Manager (OLVM), specific multipath and sanlock behavior must be configured to align host I/O retry handling with OLVM high-availability lease management.
-
-
++
 Refer to the NetApp Knowledge Base article
 https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync]
 for detailed configuration instructions.

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -161,9 +161,9 @@ If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor de
 .Steps
 
 If you are using an ONTAP SnapMirror active sync configuration with Oracle Linux Virtualization Manager (OLVM), additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events.
-+
+
 With Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-availability virtual machine (VM) failovers during unplanned storage site failover events. This occurs because the default lease renewal window can expire before multipath recovery completes.
-+
+
 Perform the configuration steps described in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to adjust the sanlock and multipath timeout values to ensure that the lease renewal window is sufficient for multipath recovery to complete during a storage failover event.
 --
 =====

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -57,11 +57,18 @@ The following table shows the Linux OS native compiled multipath parameter setti
 
 . If your storage configuration includes SnapMirror active sync, additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events. 
 +
-When SnapMirror active sync is used with Oracle Linux Virtualization Manager (OLVM), specific multipath and sanlock behavior must be configured to align host I/O retry handling with OLVM high-availability lease management.
+In SnapMirror active sync environments using Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-avaialbility VM failovers during storage failover events. This occurs because the default lease renewal window may expire before multipath recovery completes.  
+
+To prevent this, update the following host parameters:
+
+* Increase the sanlock `io_timeout` value to 15 seconds.
+* Set multipath `no_path_retry` to 24
+* Set multipath `dev_loss_tmo` to infinity.
 +
-Refer to the NetApp Knowledge Base article
-https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync]
-for detailed configuration instructions.
+Configure these multipath parameters using a drop-in configuration file in the `/etc/multipath.conf.d/` directory. For example, /etc/multipath/conf.d/90-netappl.conf. Do not modify the default `/etc/multipath.conf` file.
++
+For detailed configuration instructions, refer to the following NetApp Knowledge Base article
+https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync].
 
 
 . Verify the parameter settings and path status for your ONTAP LUNs:

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -58,9 +58,9 @@ The following table shows the Linux OS native compiled multipath parameter setti
 . If your storage configuration includes SnapMirror active sync, additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events. 
 +
 In SnapMirror active sync environments using Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-avaialbility VM failovers during storage failover events. This occurs because the default lease renewal window may expire before multipath recovery completes.  
-
++
 To prevent this, update the following host parameters:
-
++
 * Increase the sanlock `io_timeout` value to 15 seconds.
 * Set multipath `no_path_retry` to 24
 * Set multipath `dev_loss_tmo` to infinity.
@@ -69,7 +69,7 @@ Configure these multipath parameters using a drop-in configuration file in the `
 +
 For detailed configuration instructions, refer to the following NetApp Knowledge Base article
 https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync].
-+
+
 . Verify the parameter settings and path status for your ONTAP LUNs:
 +
 [source,cli]

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -59,16 +59,7 @@ The following table shows the Linux OS native compiled multipath parameter setti
 +
 In SnapMirror active sync environments using Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-avaialbility VM failovers during storage failover events. This occurs because the default lease renewal window may expire before multipath recovery completes.  
 +
-To prevent this, update the following host parameters:
-+
-* Increase the sanlock `io_timeout` value to 15 seconds.
-* Set multipath `no_path_retry` to 24
-* Set multipath `dev_loss_tmo` to infinity.
-+
-Configure these multipath parameters using a drop-in configuration file in the `/etc/multipath.conf.d/` directory. For example, /etc/multipath/conf.d/90-netappl.conf. Do not modify the default `/etc/multipath.conf` file.
-+
-For detailed configuration instructions, refer to the following NetApp Knowledge Base article
-https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync].
+Perform the configuration steps described in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync] to adjust the sanlock and multipath timeout values to ensure that the lease renewal window is sufficient for multipath recovery to complete during a storage failover event.
 
 . Verify the parameter settings and path status for your ONTAP LUNs:
 +

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -1,19 +1,15 @@
-[role="tabbed-block"]
-=====
-.Oracle Linux Standalone
---
-To ensure that multipathing is configured correctly for your host, verify that `/etc/multipath.conf` is defined and that the NetApp-recommended settings are configured for your ONTAP LUNs.
+To ensure that multipathing is configured correctly for your host, verify that the `/etc/multipath.conf` file is defined and that you have the NetApp recommended settings configured for your ONTAP LUNs.
 
-.Steps
+.Steps 
 
-. Verify that the `/etc/multipath.conf` file exists. If the file doesn't exist, create an empty, zero-byte file:
+. Verify that the `/etc/multipath.conf` file exits. If the file doesn't exist, create an empty, zero-byte file:
 +
 [source,cli]
 ----
 touch /etc/multipath.conf
 ----
 
-. The first time the `multipath.conf` file is created, you might need to enable and start the multipath services to load the recommended settings:
+. The first time the `multipath.conf` file is created, you might need to enable and start the multipath services to load the recommended settings: 
 +
 [source,cli]
 ----
@@ -27,7 +23,7 @@ systemctl start multipathd
 
 . Each time you boot the host, the empty `/etc/multipath.conf` zero-byte file automatically loads the NetApp recommended host multipath parameters as the default settings. You shouldn't need to make changes to the `/etc/multipath.conf` file for your host because the operating system is compiled with the multipath parameters that recognize and manage ONTAP LUNs correctly.
 +
-The following table shows the native Linux OS compiled multipath parameter settings for ONTAP LUNs.
+The following table shows the Linux OS native compiled multipath parameter settings for ONTAP LUNs.
 +
 .Show parameter settings
 [%collapsible]
@@ -68,11 +64,13 @@ multipath -ll
 +
 The default multipath parameters support ASA, AFF, and FAS configurations. In these configurations, a single ONTAP LUN shouldn't require more than four paths. Having more than four paths can cause problems during a storage failure.
 +
-The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
-
-*ASA configuration*
-
-An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
+The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration. 
++
+[role="tabbed-block"]
+=====
+.ASA configuration
+--
+An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time. 
 
 .Show example
 [%collapsible]
@@ -88,9 +86,10 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 12:0:1:6   sdgp 132:80  active ready running
 ----
 ====
+--
 
-*AFF or FAS configuration*
-
+.AFF or FAS configuration
+--
 An AFF or FAS configuration should have two groups of paths with higher and lower priorities. Higher priority Active/Optimized paths are served by the controller where the aggregate is located. Lower priority paths are active but non-optimized because they are served by a different controller. Non-optimized paths are only used when optimized paths aren’t available.
 
 The following example displays the output for an ONTAP LUN with two Active/Optimized paths and two Active/Non-Optimized paths:
@@ -110,60 +109,5 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
   |- 15:0:1:35 sdbx  68:176  active ready running
 ----
 ====
---
-
-.OLVM - ONTAP HA
---
-If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon. It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
-
-NetApp recommends the following drop-in file for ONTAP HA configurations to override the default `dev_loss_tmo` and `no_path_retry` values. The remaining multipath parameters align with the parameter settings table in the Oracle Linux Standalone tab.
-
-.Steps
-
-. Create the drop-in file and add the following content:
-+
-[source,cli]
-----
-cat <<'EOF' > /etc/multipath/conf.d/ontap-ha-mpath-netapp.conf
-# Finite multipath retry window aligned with sanlock io_timeout
-# default sanlock:io_timeout=10s, polling_interval=5s => no_path_retry = (8*10)/5 = 16
-
-devices {
-  device {
-    vendor "NETAPP"
-    product "LUN"
-    no_path_retry 16
-    dev_loss_tmo "infinity"
-  }
-}
-EOF
-----
-
-. Reload the multipath daemon:
-+
-[source,cli]
-----
-systemctl reload multipathd
-----
-
-. Verify the updated multipath configuration:
-+
-[source,cli]
-----
-multipath -ll
-----
---
-
-.OLVM - ONTAP SnapMirror active sync
---
-If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon. It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
-
-.Steps
-
-If you are using an ONTAP SnapMirror active sync configuration with Oracle Linux Virtualization Manager (OLVM), additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events.
-
-With Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-availability virtual machine (VM) failovers during unplanned storage site failover events. This occurs because the default lease renewal window can expire before multipath recovery completes.
-
-Perform the configuration steps described in the NetApp Knowledge Base article https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager - Sanlock Settings for ONTAP SnapMirror Active Sync] to adjust the sanlock and multipath timeout values to ensure that the lease renewal window is sufficient for multipath recovery to complete during a storage failover event.
 --
 =====

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -69,8 +69,7 @@ Configure these multipath parameters using a drop-in configuration file in the `
 +
 For detailed configuration instructions, refer to the following NetApp Knowledge Base article
 https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/Oracle_Linux_Virtualization_Manager_-_Sanlock_Settings_for_ONTAP_SnapMirror_Active_Sync[Oracle Linux Virtualization Manager – Sanlock Settings for ONTAP SnapMirror Active Sync].
-
-
++
 . Verify the parameter settings and path status for your ONTAP LUNs:
 +
 [source,cli]

--- a/_include/hu/linux-ol-multipathing.adoc
+++ b/_include/hu/linux-ol-multipathing.adoc
@@ -69,7 +69,7 @@ multipath -ll
 The default multipath parameters support ASA, AFF, and FAS configurations. In these configurations, a single ONTAP LUN shouldn't require more than four paths. Having more than four paths can cause problems during a storage failure.
 +
 The following example outputs show the correct parameter settings and path status for ONTAP LUNs in an ASA, AFF, or FAS configuration.
-+
+
 *ASA configuration*
 
 An ASA configuration optimizes all paths to a given LUN, keeping them active. This improves performance by serving I/O operations through all paths at the same time.
@@ -114,11 +114,9 @@ size=10G features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=
 
 .OLVM - ONTAP HA
 --
-If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon.
+If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon. It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
 
-It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
-
-NetApp recommends the following drop-in file for ONTAP HA configurations to override the default `dev_loss_tmo` and `no_path_retry` values. The remaining multipath parameters align with the table in the Oracle Linux Standalone tab.
+NetApp recommends the following drop-in file for ONTAP HA configurations to override the default `dev_loss_tmo` and `no_path_retry` values. The remaining multipath parameters align with the parameter settings table in the Oracle Linux Standalone tab.
 
 .Steps
 
@@ -158,13 +156,11 @@ multipath -ll
 
 .OLVM - ONTAP SnapMirror active sync
 --
-If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon.
-
-It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
+If you are using Oracle Linux Virtualization Manager (OLVM), Linux hypervisor default multipath parameters are controlled by the VDSM daemon. It is not recommended to directly modify default OLVM VDSM-generated `/etc/multipath.conf` values. Override the default multipath values by using a multipath drop-in file.
 
 .Steps
 
-. If you are using an ONTAP SnapMirror active sync configuration with Oracle Linux Virtualization Manager (OLVM), additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events.
+If you are using an ONTAP SnapMirror active sync configuration with Oracle Linux Virtualization Manager (OLVM), additional configuration is required to ensure correct host and virtual machine behavior during SnapMirror active sync storage failover events.
 +
 With Oracle Linux Virtualization Manager (OLVM), default sanlock and multipath timeout values can result in unintended high-availability virtual machine (VM) failovers during unplanned storage site failover events. This occurs because the default lease renewal window can expire before multipath recovery completes.
 +

--- a/hu-ol-8x.adoc
+++ b/hu-ol-8x.adoc
@@ -27,7 +27,7 @@ You can use multipathing with Oracle Linux 8.x to manage ONTAP LUNs.
 
 NOTE: You can use the link:hu-rhel-8x.html#rhel-rhck[recommended settings for Red Hat Enterprise Linux (RHEL) 8.x] to configure Red Hat Compatible Kernel for Oracle Linux 8.x.
 
-include::_include/hu/linux-ol-multipathing.adoc[]
+include::_include/hu/linux-ol-8-9-multipathing.adoc[]
 
 == Step 4: Confirm the iSCSI configuration for your host
 

--- a/hu-ol-9x.adoc
+++ b/hu-ol-9x.adoc
@@ -25,7 +25,7 @@ include::_include/hu/install-linux-host-utilities-80.adoc[]
 
 You can use multipathing with Oracle Linux 9.x to manage ONTAP LUNs.
 
-include::_include/hu/linux-ol-multipathing.adoc[]
+include::_include/hu/linux-ol-8-9-multipathing.adoc[]
 
 == Step 4: Confirm the iSCSI configuration for your host
 


### PR DESCRIPTION
Add information for setting multipath timeout parameters for OLVM with SnapMirror active sync in Oracle Linux versions 8.x and 9.x. Reference KB article for configuration info.