### PR TITLE
Updates for SanHost AIX support for SnapMirror active sync active/active vs active/standby

### DIFF
--- a/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
+++ b/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
@@ -11,12 +11,7 @@ By default, the AIX OS enforces a shorter I/O timeout when there are no availabl
 --
 Beginning with ONTAP 9.11.1, SnapMirror active sync is supported for an AIX host. The support behavior differs by ONTAP release:
 
-  - ONTAP 9.11.1 to 9.18.1: SnapMirror active sync is supported in Active/Standby configuration.
-  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in an Active/Active configuration, enabling non-disruptive SnapMirror active sync operations.
-
-  For SnapMirror active sync configuration guidance:
-  
-    - ONTAP 9.11.1 to 9.18.1, see the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
-    - ONTAP 9.19.1 and later, see the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
+  - ONTAP 9.11.1 to 9.18.1: SnapMirror active sync is supported in Active/Standby configuration. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
+  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in an Active/Active configuration, enabling non-disruptive SnapMirror active sync operations. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
 --
 ====

--- a/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
+++ b/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
@@ -12,6 +12,6 @@ By default, the AIX OS enforces a shorter I/O timeout when there are no availabl
 Beginning with ONTAP 9.11.1, SnapMirror active sync is supported for an AIX host. The support behavior differs by ONTAP release:
 
   - ONTAP 9.11.1 to 9.18.1: SnapMirror active sync is supported in Active/Standby configuration. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
-  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in an Active/Active configuration, enabling non-disruptive SnapMirror active sync operations. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
+  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in Active/Active configuration, enabling non-disruptive SnapMirror active sync operations. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
 --
 ====

--- a/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
+++ b/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
@@ -9,10 +9,14 @@ By default, the AIX OS enforces a shorter I/O timeout when there are no availabl
 
 .SnapMirror active sync
 --
-Beginning with ONTAP 9.11.1, SnapMirror active sync is supported for an AIX host. The primary cluster in an AIX configuration is the "active" cluster. 
+Beginning with ONTAP 9.11.1, SnapMirror active sync is supported for an AIX host. The support behavior differs by ONTAP release:
 
-In an AIX configuration, failovers are disruptive. With each failover, you need to perform a re-scan on the host for I/O operations to resume. 
+  - ONTAP 9.11.1 to 9.18.1: SnapMirror active sync is supported in Active/Standby configuration.
+  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in an Active/Active configuration, enabling non-disruptive SnapMirror active sync operations.
 
-Refer to the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync^]. 
+  For SnapMirror active sync configuration guidance:
+  
+    - ONTAP 9.11.1 to 9.18.1, see the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
+    - ONTAP 9.19.1 and later, see the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
 --
 ====

--- a/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
+++ b/_include/hu/aix-recommended-settings-mcc-snapmirror-active-sync.adoc
@@ -9,9 +9,10 @@ By default, the AIX OS enforces a shorter I/O timeout when there are no availabl
 
 .SnapMirror active sync
 --
-Beginning with ONTAP 9.11.1, SnapMirror active sync is supported for an AIX host. The support behavior differs by ONTAP release:
+SnapMirror active sync is supported for an AIX host. The support behavior differs by ONTAP release:
 
-  - ONTAP 9.11.1 to 9.18.1: SnapMirror active sync is supported in Active/Standby configuration. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
-  - ONTAP 9.19.1 and later: SnapMirror active sync is supported in Active/Active configuration, enabling non-disruptive SnapMirror active sync operations. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
+  - Beginning with ONTAP 9.19.1, SnapMirror active sync is supported in Active/Active configuration, enabling non-disruptive SnapMirror active sync operations. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/SnapMirror_active_sync_support_for_AIX%3A_behavior_by_ONTAP_release_and_migration_guidance[SnapMirror active sync support for AIX: behavior by ONTAP release and migration guidance^].
+  - For ONTAP 9.11.1 to 9.18.1, SnapMirror active sync is supported in Active/Standby configuration. See the Knowledge Base article link:https://kb.netapp.com/on-prem/ontap/DP/SnapMirror/SnapMirror-KBs/How_to_configure_AIX_Host_for_SnapMirror_active_sync_in_ONTAP[How to configure an AIX host for SnapMirror active sync in ONTAP 9.11.1 to 9.18.1^].
+
 --
 ====


### PR DESCRIPTION
Added information about ONTAP SnapMirror releases supporting active/active vs active/standby configurations. Added links to relevant knowledge base articles for detailed information.